### PR TITLE
Implement piece table for Buffer struct [Part 1]

### DIFF
--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -36,7 +36,7 @@ impl App {
 		self.app_mode
 	}
 
-	pub fn get_text_as_iter(&self) -> Vec<&str> {
+	pub fn get_text_as_iter(&self) -> Vec<String> {
 		vec![self.buffer.as_str()]
 	}
 

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -1,3 +1,5 @@
+use crate::utils::Cursor;
+
 use super::buffer::Buffer;
 
 #[derive(Copy, Clone, PartialEq)]
@@ -8,7 +10,7 @@ pub enum AppMode {
 
 pub struct App {
 	buffer: Buffer,
-	cursor_position: usize,
+	cursor_main: Cursor,
 	app_mode: AppMode,
 }
 
@@ -16,7 +18,7 @@ impl App {
 	pub fn new() -> App {
 		App {
 			buffer: Buffer::new(),
-			cursor_position: 0,
+			cursor_main: Cursor::new(),
 			app_mode: AppMode::Edit,
 		}
 	}
@@ -26,8 +28,8 @@ impl App {
 		&self.buffer
 	}
 
-	pub fn cursor_position(&self) -> usize {
-		self.cursor_position
+	pub fn cursor_main(&self) -> &Cursor {
+		&self.cursor_main
 	}
 
 	pub fn app_mode(&self) -> AppMode {
@@ -39,26 +41,18 @@ impl App {
 	}
 
 	pub fn add_char(&mut self, c: char) {
-		self.buffer.insert(self.cursor_position, c);
-		self.cursor_position += 1;
+		self.buffer.insert(&mut self.cursor_main, c);
 	}
 
 	pub fn remove_char(&mut self) {
-		if self.cursor_position > 1 {
-			self.cursor_position -= 1;
-			self.buffer.remove(self.cursor_position);
-		}
+		self.buffer.remove(&mut self.cursor_main);
 	}
 
 	pub fn move_cursor_left(&mut self) {
-		if self.cursor_position > 0 {
-			self.cursor_position -= 1;
-		}
+		self.buffer.move_cursor_left(&mut self.cursor_main);
 	}
 
 	pub fn move_cursor_right(&mut self) {
-		if self.cursor_position < self.buffer.len() - 1 {
-			self.cursor_position += 1;
-		}
+		self.buffer.move_cursor_right(&mut self.cursor_main);
 	}
 }

--- a/src/model/buffer.rs
+++ b/src/model/buffer.rs
@@ -49,8 +49,8 @@ impl BufferNode {
 }
 
 pub struct Buffer {
-	original_str: Vec<char>,
-	added_str: Vec<char>,
+	original_str: Vec<u8>,
+	added_str: Vec<u8>,
 	node_list: Vec<BufferNode>,
 
 	// an important invariant is how the cursor is going to be placed.
@@ -84,7 +84,7 @@ impl Buffer {
 		let offsets = Buffer::get_offsets(&original_str);
 		let first_node = BufferNode::new(BufferType::Original, 0, original_str.len(), offsets);
 		Buffer {
-			original_str: original_str.chars().collect(),
+			original_str: original_str.as_bytes().to_vec(),
 			added_str: Vec::new(),
 			node_list: vec![first_node],
 		}
@@ -105,7 +105,7 @@ impl Buffer {
 		let new_node = BufferNode::new(BufferType::Added, idx, offset, line_offsets);
 
 		// append string to add_str
-		let mut vec_converted = string.chars().collect::<Vec<char>>();
+		let mut vec_converted = string.as_bytes().to_vec();
 		self.added_str.append(&mut vec_converted);
 
 		if self.node_list.len() == 0 {
@@ -214,7 +214,7 @@ impl Buffer {
 				BufferType::Original => self.original_str[index + node_offset],
 				BufferType::Added => self.added_str[index + node_offset],
 			};
-			if removed_char == '\n' {
+			if removed_char == '\n' as u8 {
 				line_offsets.pop();
 			}
 			let new_node = BufferNode::new(from, index, node_offset, line_offsets);
@@ -239,7 +239,7 @@ impl Buffer {
 				BufferType::Original => self.original_str[index + node_offset - 1],
 				BufferType::Added => self.added_str[index + node_offset - 1],
 			};
-			if removed_char == '\n' {
+			if removed_char == '\n' as u8 {
 				left_line_offsets.pop();
 			}
 

--- a/src/model/buffer.rs
+++ b/src/model/buffer.rs
@@ -2,13 +2,13 @@ use crate::utils::Cursor;
 #[allow(dead_code)]
 
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 enum BufferType {
 	Original,
 	Added,
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 struct BufferNode {
 	from: BufferType,
 	index: usize,
@@ -41,6 +41,10 @@ impl BufferNode {
 	fn line_offsets(&mut self) -> &mut Vec<usize> {
 		&mut self.line_offsets
 	}
+
+	fn last_line_offset(&self) -> usize {
+		*self.line_offsets.last().unwrap()
+	}
 }
 
 pub struct Buffer {
@@ -72,18 +76,82 @@ impl Buffer {
 		let offsets = Buffer::get_offsets(&original_str);
 		let first_node = BufferNode::new(BufferType::Original, 0, original_str.len(), offsets);
 		Buffer {
-			original_str: String::new(),
+			original_str: original_str,
 			added_str: String::new(),
 			node_list: vec![first_node],
 		}
 	}
 
 	pub fn insert(&mut self, cursor: &mut Cursor, ch: char) {
-		todo!();
+		let mut string = String::new();
+		string.push(ch);
+		self.insert_str(cursor, string);
 	}
 
-	pub fn insert_str(&mut self, cursor: &mut Cursor, string: &str) {
-		todo()!;
+	pub fn insert_str(&mut self, cursor: &mut Cursor, string: String) {
+		// get the node fields and add the new node
+		let line_offsets = Buffer::get_offsets(&string);
+		let num_lines = line_offsets.len();
+		let idx = self.added_str.len();
+		let offset = string.len();
+		let new_node = BufferNode::new(BufferType::Added, idx, offset, line_offsets);
+
+		// append string to add_str
+		self.added_str.push_str(&string);
+
+		// split the current node we are on into two
+		let node_to_split = &mut self.node_list[cursor.node_idx];
+		if cursor.node_offset == node_to_split.offset() {
+			// just insert the new node after the current one
+			// this should only happen when the cursor is at the end of the buffer
+			assert!(cursor.node_idx == self.node_list.len() - 1);
+			// update cursor before losing ownership of the new node
+			cursor.node_idx += 1;
+			cursor.node_offset = new_node.offset();
+			cursor.line_idx = num_lines - 1;
+			let last_offset = new_node.last_line_offset();
+			cursor.line_offset = cursor.node_offset - last_offset;
+			self.node_list.push(new_node);
+
+		} else if cursor.node_offset == 0 {
+			// just insert the new node before the current one
+			self.node_list.insert(cursor.node_offset, new_node);
+			cursor.node_idx += 1;
+			assert_eq!(cursor.node_offset, 0);
+			assert_eq!(cursor.line_idx, 0);
+			assert_eq!(cursor.line_offset, 0);
+		} else {
+			// split the node into two and insert it in between
+			let from = node_to_split.from();
+			let index = node_to_split.index();
+			let offset = node_to_split.offset();
+			let line_offsets = &mut node_to_split.line_offsets();
+
+			// split the line_offsets based on where the cursor is
+			let drain_from_idx = cursor.line_idx;
+			println!("done part 0! drain from idx {}", drain_from_idx);
+			let left_line_offsets = line_offsets.drain(..=drain_from_idx).collect();
+			let node_offset = cursor.node_offset;
+			let mut right_line_offsets: Vec<usize> = line_offsets.drain( .. )
+												.map(|x| x - node_offset)
+												.collect();
+			right_line_offsets.insert(0, 0);
+			// construct left and right nodes
+			let left_node = BufferNode::new(from, index, cursor.node_offset, left_line_offsets );
+			let right_node = BufferNode::new(from, index + cursor.node_offset, offset - cursor.node_offset, right_line_offsets);
+
+			// do this in case we're inserting at the end of the vector
+			self.node_list.insert(cursor.node_idx, left_node);
+			self.node_list.insert(cursor.node_idx + 1, new_node);
+			self.node_list.insert(cursor.node_idx + 2, right_node);
+			self.node_list.remove(cursor.node_idx + 3);
+
+			// update the cursor
+			cursor.node_idx += 2;
+			cursor.line_offset = 0;
+			cursor.node_offset = 0;
+			cursor.line_idx = 0;
+		}
 	}
 
 	pub fn remove(&mut self, cursor: &mut Cursor) -> char {
@@ -126,45 +194,172 @@ mod tests {
 	use super::*;
 
 	#[test]
-	fn test_get_offsets_none() {
+	fn get_offsets_none() {
 		let string = String::from("abc");
 		let offsets = Buffer::get_offsets(&string);
 		assert_eq!(offsets, &[0]);
 	}
 
 	#[test]
-	fn test_get_offsets_first() {
+	fn get_offsets_first() {
 		let string = String::from("\nabc");
 		let offsets = Buffer::get_offsets(&string);
 		assert_eq!(offsets, &[0, 1]);
 	}
 
 	#[test]
-	fn test_get_offsets_last() {
+	fn get_offsets_last() {
 		let string = String::from("abc\n");
 		let offsets = Buffer::get_offsets(&string);
 		assert_eq!(offsets, &[0, 4]);
 	}
 
 	#[test]
-	fn test_get_offsets_only() {
+	fn get_offsets_only() {
 		let string = String::from("\n");
 		let offsets = Buffer::get_offsets(&string);
 		assert_eq!(offsets, &[0, 1]);
 	}
 
 	#[test]
-	fn test_get_offsets_two() {
+	fn get_offsets_two() {
 		let string = String::from("\nabc\n");
 		let offsets = Buffer::get_offsets(&string);
 		assert_eq!(offsets, &[0, 1, 5]);
 	}
 
 	#[test]
-	fn test_get_offsets_consecutive() {
+	fn get_offsets_consecutive() {
 		let string = String::from("\n\n\n");
 		let offsets = Buffer::get_offsets(&string);
 		assert_eq!(offsets, &[0, 1, 2, 3]);
 	}
 
+	#[test]
+	fn insert_char_into_fresh_buffer() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::new();
+		buffer.insert(&mut cursor, 'a');
+
+		assert_eq!(buffer.original_str, "", "original_str mismatch");
+		assert_eq!(buffer.added_str, "a", "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 0, vec![0] );
+		let node_1 = BufferNode::new(BufferType::Added, 0, 1, vec![0] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_newl_into_fresh_buffer() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::new();
+		buffer.insert(&mut cursor, '\n');
+
+		assert_eq!(buffer.original_str, "", "original_str mismatch");
+		assert_eq!(buffer.added_str, "\n", "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 0, vec![0] );
+		let node_1 = BufferNode::new(BufferType::Added, 0, 1, vec![0, 1] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_newlnewl_into_fresh_buffer() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::new();
+		let inserted_str = String::from("\n\n");
+		buffer.insert_str(&mut cursor, inserted_str);
+
+		assert_eq!(buffer.original_str, "", "original_str mismatch");
+		assert_eq!(buffer.added_str, "\n\n", "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 0, vec![0] );
+		let node_1 = BufferNode::new(BufferType::Added, 0, 2, vec![0, 1, 2] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 2, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_before_node() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
+
+		buffer.insert_str(&mut cursor, String::from("1\n2"));
+
+		assert_eq!(buffer.original_str, "abdc\nef", "original_str mismatch");
+		assert_eq!(buffer.added_str, "1\n2", "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+		let node_1 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_after_node() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
+		cursor.node_idx = 0;
+		cursor.node_offset = 7;
+		cursor.line_idx = 1;
+		cursor.line_offset = 2;
+
+		buffer.insert_str(&mut cursor, String::from("1\n2"));
+
+		assert_eq!(buffer.original_str, "abdc\nef", "original_str mismatch");
+		assert_eq!(buffer.added_str, "1\n2", "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
+		let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_mid_node() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("abdc\nef\ng"));
+		cursor.node_idx = 0;
+		cursor.node_offset = 5;
+		cursor.line_idx = 1;
+		cursor.line_offset = 0;
+
+		buffer.insert_str(&mut cursor, String::from("1\n2"));
+		//|abdc\n|1\n2|ef\ng
+
+		assert_eq!(buffer.original_str, "abdc\nef\ng", "original_str mismatch");
+		assert_eq!(buffer.added_str, "1\n2", "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 5, vec![0, 5] );
+		let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+		let node_2 = BufferNode::new(BufferType::Original, 5, 4, vec![0, 3] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1, node_2], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
 }

--- a/src/model/buffer.rs
+++ b/src/model/buffer.rs
@@ -1,3 +1,5 @@
+use std::str;
+
 use crate::utils::Cursor;
 
 #[allow(dead_code)]
@@ -273,8 +275,21 @@ impl Buffer {
 		todo!();
 	}
 
-	pub fn as_str(&self) -> &str {
-		todo!();
+	pub fn as_str(&self) -> String {
+		let serialised_str = self.node_list.iter()
+								.fold( String::new(), |mut acc, node| {
+									let source = match node.from() {
+										BufferType::Original => &self.original_str,
+										BufferType::Added => &self.added_str,
+									};
+									let slice = &source[node.index()..node.index() + node.offset()];
+									let chunk = str::from_utf8(slice).unwrap();
+									acc.push_str(chunk);
+									acc
+									}
+								);
+		serialised_str
+
 	}
 
 	pub fn len(&self) -> usize {

--- a/src/model/buffer.rs
+++ b/src/model/buffer.rs
@@ -1,4 +1,5 @@
 use crate::utils::Cursor;
+
 #[allow(dead_code)]
 
 
@@ -61,6 +62,7 @@ pub struct Buffer {
 }
 
 impl Buffer {
+
 	fn get_offsets(string: &str) -> Vec<usize> {
 		// Whelp this looks gross. Probably prettify or rewrite later on
 		let acc = vec![0];
@@ -71,11 +73,10 @@ impl Buffer {
 	}
 
 	pub fn new() -> Buffer {
-		let first_node = BufferNode::new(BufferType::Original, 0, 0, vec![0]);
 		Buffer {
 			original_str: Vec::new(),
 			added_str: Vec::new(),
-			node_list: vec![first_node],
+			node_list: Vec::new(),
 		}
 	}
 
@@ -106,6 +107,16 @@ impl Buffer {
 		// append string to add_str
 		let mut vec_converted = string.chars().collect::<Vec<char>>();
 		self.added_str.append(&mut vec_converted);
+
+		if self.node_list.len() == 0 {
+			cursor.node_idx = 0;
+			cursor.node_offset = offset;
+			cursor.line_idx = num_lines - 1;
+			let last_offset = new_node.last_line_offset();
+			cursor.line_offset = cursor.node_offset - last_offset;
+			self.node_list.push(new_node);
+			return;
+		}
 
 		// split the current node we are on into two
 		let node_to_split = &mut self.node_list[cursor.node_idx];
@@ -166,28 +177,30 @@ impl Buffer {
 		// 	two nodes or in the middle of a single node. both cases are handled
 		//  quite differently
 
+		if self.node_list.len() == 0 {
+			return;
+		}
+
+		if cursor.node_idx == 0 && cursor.node_offset == 0 {
+			return;
+		}
+
 		let mut node_idx = cursor.node_idx;
 		let mut node_offset = cursor.node_offset;
 
-
-		if node_offset == 0 {
-			// if we're at the head of the file there's nothing to do;
-			if node_idx == 0 { return; }
-			// else reference the previous node
+		if node_offset == 0 && node_idx >= 1 {
 			node_idx -= 1;
 			node_offset = self.node_list[node_idx].offset();
 		}
 
 		let from = self.node_list[node_idx].from();
+		let offset = self.node_list[node_idx].offset();
 		let index = self.node_list[node_idx].index();
 		let line_offsets = &mut self.node_list[node_idx].line_offsets();
 		let mut line_offsets: Vec<usize> = line_offsets.drain(..).collect();
 
 		if node_offset == self.node_list[node_idx].offset() {
-			// an edge case is that this is the empty node that appears when
-			// we've just constructed a file. in that case we should return as well
-			if node_idx == 0 &&  node_offset == 0 { return; }
-			// just reduce the offset value by 1 here
+			// just reduce the node offset by 1 here
 			node_offset -= 1;
 			if node_offset == 0 {
 				// node is now empty, just delete it and move the cursor
@@ -207,7 +220,7 @@ impl Buffer {
 			let new_node = BufferNode::new(from, index, node_offset, line_offsets);
 			// in this case the cursor position does not need to be updated?
 			//  unless the cursor was at the end of the entire buffer
-			if cursor.node_idx == self.node_list.size() - 1 {
+			if node_idx == self.node_list.len() - 1 {
 				cursor.node_offset -= 1;
 			}
 			self.node_list.insert(node_idx, new_node);
@@ -215,7 +228,7 @@ impl Buffer {
 		} else {
 			// split the line_offsets based on where the cursor is
 			let drain_from_idx = cursor.line_idx;
-			let left_line_offsets = line_offsets.drain(..=drain_from_idx).collect();
+			let mut left_line_offsets: Vec<usize> = line_offsets.drain(..=drain_from_idx).collect();
 			let node_offset = cursor.node_offset;
 			let mut right_line_offsets: Vec<usize> = line_offsets.drain( .. )
 												.map(|x| x - node_offset)
@@ -223,8 +236,8 @@ impl Buffer {
 			right_line_offsets.insert(0, 0);
 
 			let removed_char = match from {
-				BufferType::Original => self.original_str[index + node_offset],
-				BufferType::Added => self.added_str[index + node_offset],
+				BufferType::Original => self.original_str[index + node_offset - 1],
+				BufferType::Added => self.added_str[index + node_offset - 1],
 			};
 			if removed_char == '\n' {
 				left_line_offsets.pop();
@@ -288,176 +301,5 @@ impl Buffer {
 }
 
 #[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn get_offsets_none() {
-		let string = String::from("abc");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0]);
-	}
-
-	#[test]
-	fn get_offsets_first() {
-		let string = String::from("\nabc");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 1]);
-	}
-
-	#[test]
-	fn get_offsets_last() {
-		let string = String::from("abc\n");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 4]);
-	}
-
-	#[test]
-	fn get_offsets_only() {
-		let string = String::from("\n");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 1]);
-	}
-
-	#[test]
-	fn get_offsets_two() {
-		let string = String::from("\nabc\n");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 1, 5]);
-	}
-
-	#[test]
-	fn get_offsets_consecutive() {
-		let string = String::from("\n\n\n");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 1, 2, 3]);
-	}
-
-	#[test]
-	fn insert_char_into_fresh_buffer() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::new();
-		buffer.insert(&mut cursor, 'a');
-
-		assert_eq!(buffer.original_str, "", "original_str mismatch");
-		assert_eq!(buffer.added_str, "a", "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 0, vec![0] );
-		let node_1 = BufferNode::new(BufferType::Added, 0, 1, vec![0] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_newl_into_fresh_buffer() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::new();
-		buffer.insert(&mut cursor, '\n');
-
-		assert_eq!(buffer.original_str, "", "original_str mismatch");
-		assert_eq!(buffer.added_str, "\n", "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 0, vec![0] );
-		let node_1 = BufferNode::new(BufferType::Added, 0, 1, vec![0, 1] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_newlnewl_into_fresh_buffer() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::new();
-		let inserted_str = String::from("\n\n");
-		buffer.insert_str(&mut cursor, inserted_str);
-
-		assert_eq!(buffer.original_str, "", "original_str mismatch");
-		assert_eq!(buffer.added_str, "\n\n", "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 0, vec![0] );
-		let node_1 = BufferNode::new(BufferType::Added, 0, 2, vec![0, 1, 2] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 2, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_before_node() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
-
-		buffer.insert_str(&mut cursor, String::from("1\n2"));
-
-		assert_eq!(buffer.original_str, "abdc\nef", "original_str mismatch");
-		assert_eq!(buffer.added_str, "1\n2", "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
-		let node_1 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_after_node() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
-		cursor.node_idx = 0;
-		cursor.node_offset = 7;
-		cursor.line_idx = 1;
-		cursor.line_offset = 2;
-
-		buffer.insert_str(&mut cursor, String::from("1\n2"));
-
-		assert_eq!(buffer.original_str, "abdc\nef", "original_str mismatch");
-		assert_eq!(buffer.added_str, "1\n2", "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
-		let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_mid_node() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("abdc\nef\ng"));
-		cursor.node_idx = 0;
-		cursor.node_offset = 5;
-		cursor.line_idx = 1;
-		cursor.line_offset = 0;
-
-		buffer.insert_str(&mut cursor, String::from("1\n2"));
-		//|abdc\n|1\n2|ef\ng
-
-		assert_eq!(buffer.original_str, "abdc\nef\ng", "original_str mismatch");
-		assert_eq!(buffer.added_str, "1\n2", "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 5, vec![0, 5] );
-		let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
-		let node_2 = BufferNode::new(BufferType::Original, 5, 4, vec![0, 3] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1, node_2], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-}
+#[path = "tests/buffer_tests.rs"]
+mod buffer_tests;

--- a/src/model/buffer.rs
+++ b/src/model/buffer.rs
@@ -1,37 +1,170 @@
+use crate::utils::Cursor;
+#[allow(dead_code)]
+
+
+#[derive(Copy, Clone)]
+enum BufferType {
+	Original,
+	Added,
+}
+
+#[derive(Clone)]
+struct BufferNode {
+	from: BufferType,
+	index: usize,
+	offset: usize,
+	line_offsets: Vec<usize>,
+}
+
+impl BufferNode {
+	fn new(from: BufferType, index: usize, offset: usize, line_offsets: Vec<usize>) -> BufferNode {
+		BufferNode{
+			from,
+			index,
+			offset,
+			line_offsets,
+		}
+	}
+
+	fn index(&self) -> usize {
+		self.index
+	}
+
+	fn offset(&self) -> usize {
+		self.offset
+	}
+
+	fn from(&self) -> BufferType {
+		self.from
+	}
+
+	fn line_offsets(&mut self) -> &mut Vec<usize> {
+		&mut self.line_offsets
+	}
+}
+
 pub struct Buffer {
-	contents: String
+	original_str: String,
+	added_str: String,
+	node_list: Vec<BufferNode>,
 }
 
 impl Buffer {
+	fn get_offsets(string: &str) -> Vec<usize> {
+		// Whelp this looks gross. Probably prettify or rewrite later on
+		let acc = vec![0];
+		let index_list: Vec<usize> = (1..=string.len()).collect();
+		string.chars().zip(index_list.iter())
+						.filter(|(c, _)| *c == '\n')
+						.fold(acc, |mut list, (c, idx)| {list.push(*idx); list})
+	}
+
 	pub fn new() -> Buffer {
+		let first_node = BufferNode::new(BufferType::Original, 0, 0, vec![0]);
 		Buffer {
-			contents: String::new()
+			original_str: String::new(),
+			added_str: String::new(),
+			node_list: vec![first_node],
 		}
 	}
 
-	pub fn with_string(string: String) -> Buffer {
+	pub fn with_contents(original_str: String) -> Buffer {
+		let offsets = Buffer::get_offsets(&original_str);
+		let first_node = BufferNode::new(BufferType::Original, 0, original_str.len(), offsets);
 		Buffer {
-			contents: string
+			original_str: String::new(),
+			added_str: String::new(),
+			node_list: vec![first_node],
 		}
 	}
 
-	pub fn insert(&mut self, idx: usize, ch: char) {
-		self.contents.insert(idx, ch);
+	pub fn insert(&mut self, cursor: &mut Cursor, ch: char) {
+		todo!();
 	}
 
-	pub fn insert_str(&mut self, idx: usize, string: &str) {
-		self.contents.insert_str(idx, string);
+	pub fn insert_str(&mut self, cursor: &mut Cursor, string: &str) {
+		todo()!;
 	}
 
-	pub fn remove(&mut self, idx: usize) -> char {
-		self.contents.remove(idx)
+	pub fn remove(&mut self, cursor: &mut Cursor) -> char {
+		todo!();
+	}
+
+	pub fn remove_word(&mut self, cursor: &mut Cursor) -> char {
+		todo!();
 	}
 
 	pub fn as_str(&self) -> &str {
-		self.contents.as_str()
+		todo!();
 	}
 
 	pub fn len(&self) -> usize {
-		self.contents.len()
+		todo!();
 	}
+
+
+	pub fn move_cursor_up(&self, cursor: &mut Cursor) {
+		todo!();
+	}
+
+	pub fn move_cursor_down(&self, cursor: &mut Cursor) {
+		todo!();
+	}
+
+	pub fn move_cursor_left(&self, cursor: &mut Cursor) {
+		todo!();
+	}
+
+	pub fn move_cursor_right(&self, cursor: &mut Cursor) {
+		todo!();
+	}
+
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_get_offsets_none() {
+		let string = String::from("abc");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0]);
+	}
+
+	#[test]
+	fn test_get_offsets_first() {
+		let string = String::from("\nabc");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 1]);
+	}
+
+	#[test]
+	fn test_get_offsets_last() {
+		let string = String::from("abc\n");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 4]);
+	}
+
+	#[test]
+	fn test_get_offsets_only() {
+		let string = String::from("\n");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 1]);
+	}
+
+	#[test]
+	fn test_get_offsets_two() {
+		let string = String::from("\nabc\n");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 1, 5]);
+	}
+
+	#[test]
+	fn test_get_offsets_consecutive() {
+		let string = String::from("\n\n\n");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 1, 2, 3]);
+	}
+
 }

--- a/src/model/buffer.rs
+++ b/src/model/buffer.rs
@@ -292,11 +292,6 @@ impl Buffer {
 
 	}
 
-	pub fn len(&self) -> usize {
-		todo!();
-	}
-
-
 	pub fn move_cursor_up(&self, cursor: &mut Cursor) {
 		todo!();
 	}

--- a/src/model/tests/buffer_tests.rs
+++ b/src/model/tests/buffer_tests.rs
@@ -2,8 +2,8 @@
 mod buffer_tests {
 	use super::super::*;
 
-	fn stov(string: &'static str) -> Vec<char> {
-		string.chars().collect::<Vec<char>>()
+	fn stov(string: &'static str) -> Vec<u8> {
+		string.as_bytes().to_vec()
 	}
 
 	// get_offsets_tests

--- a/src/model/tests/buffer_tests.rs
+++ b/src/model/tests/buffer_tests.rs
@@ -1,0 +1,324 @@
+#[cfg(test)]
+mod buffer_tests {
+	use super::super::*;
+
+	fn stov(string: &'static str) -> Vec<char> {
+		string.chars().collect::<Vec<char>>()
+	}
+
+	// get_offsets_tests
+	#[test]
+	fn get_offsets_none() {
+		let string = String::from("abc");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0]);
+	}
+
+	#[test]
+	fn get_offsets_first() {
+		let string = String::from("\nabc");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 1]);
+	}
+
+	#[test]
+	fn get_offsets_last() {
+		let string = String::from("abc\n");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 4]);
+	}
+
+	#[test]
+	fn get_offsets_only() {
+		let string = String::from("\n");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 1]);
+	}
+
+	#[test]
+	fn get_offsets_two() {
+		let string = String::from("\nabc\n");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 1, 5]);
+	}
+
+	#[test]
+	fn get_offsets_consecutive() {
+		let string = String::from("\n\n\n");
+		let offsets = Buffer::get_offsets(&string);
+		assert_eq!(offsets, &[0, 1, 2, 3]);
+	}
+
+	// insert_tests
+	#[test]
+	fn insert_char_into_fresh_buffer() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::new();
+		buffer.insert(&mut cursor, 'a');
+
+		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov("a"), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0] );
+		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_newl_into_fresh_buffer() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::new();
+		buffer.insert(&mut cursor, '\n');
+
+		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov("\n"), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0, 1] );
+		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_newlnewl_into_fresh_buffer() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::new();
+		let inserted_str = String::from("\n\n");
+		buffer.insert_str(&mut cursor, inserted_str);
+
+		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov("\n\n"), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Added, 0, 2, vec![0, 1, 2] );
+		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 2, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_before_node() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
+
+		buffer.insert_str(&mut cursor, String::from("1\n2"));
+
+		assert_eq!(buffer.original_str, stov("abdc\nef"), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+		let node_1 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_after_node() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
+		cursor.node_idx = 0;
+		cursor.node_offset = 7;
+		cursor.line_idx = 1;
+		cursor.line_offset = 2;
+
+		buffer.insert_str(&mut cursor, String::from("1\n2"));
+
+		assert_eq!(buffer.original_str, stov("abdc\nef"), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
+		let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn insert_mid_node() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("abdc\nef\ng"));
+		cursor.node_idx = 0;
+		cursor.node_offset = 5;
+		cursor.line_idx = 1;
+		cursor.line_offset = 0;
+
+		buffer.insert_str(&mut cursor, String::from("1\n2"));
+
+		assert_eq!(buffer.original_str, stov("abdc\nef\ng"), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 5, vec![0, 5] );
+		let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+		let node_2 = BufferNode::new(BufferType::Original, 5, 4, vec![0, 3] );
+		assert_eq!(buffer.node_list, vec![node_0, node_1, node_2], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn remove_from_fresh_buffer() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::new();
+
+		buffer.remove(&mut cursor);
+
+		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+		assert_eq!(buffer.node_list, vec![], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn remove_left_from_node() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("abc"));
+
+		buffer.remove(&mut cursor);
+
+		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 3, vec![0]);
+		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn remove_from_last_of_node() {
+		let mut cursor = Cursor::new();
+		cursor.node_offset = 3;
+		let mut buffer = Buffer::with_contents(String::from("abc"));
+
+		buffer.remove(&mut cursor);
+
+		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 2, vec![0]);
+		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn remove_from_mid_of_node() {
+		let mut cursor = Cursor::new();
+		cursor.node_offset = 2;
+		let mut buffer = Buffer::with_contents(String::from("abc"));
+
+		buffer.remove(&mut cursor);
+
+		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 1, vec![0]);
+		let node_1 = BufferNode::new(BufferType::Original, 2, 1, vec![0]);
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn remove_twice_from_mid_of_node() {
+		let mut cursor = Cursor::new();
+		cursor.node_offset = 2;
+		let mut buffer = Buffer::with_contents(String::from("abc"));
+
+		buffer.remove(&mut cursor);
+		buffer.remove(&mut cursor);
+
+		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 2, 1, vec![0]);
+		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn remove_with_two_nodes() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("abc"));
+
+		buffer.insert_str(&mut cursor, String::from("\ndef\n"));
+		cursor.node_idx = 1;
+		cursor.node_offset = 0;
+		cursor.line_idx = 0;
+		cursor.line_offset = 0;
+
+		buffer.remove(&mut cursor);
+		buffer.remove(&mut cursor);
+
+		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+		assert_eq!(buffer.added_str, stov("\ndef\n"), "added_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 1]);
+		let node_1 = BufferNode::new(BufferType::Original, 0, 3, vec![0]);
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+
+	#[test]
+	fn remove_with_newlines() {
+		let mut cursor = Cursor::new();
+		let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
+		cursor.node_offset = 4;
+		cursor.line_idx = 2;
+		cursor.line_offset = 0;
+
+		buffer.remove(&mut cursor);
+
+		assert_eq!(buffer.original_str, stov("\nde\nf\n"), "original_str mismatch");
+
+		let node_0 = BufferNode::new(BufferType::Original, 0, 3, vec![0, 1]);
+		let node_1 = BufferNode::new(BufferType::Original, 4, 2, vec![0, 2]);
+		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+	}
+}

--- a/src/model/tests/buffer_tests.rs
+++ b/src/model/tests/buffer_tests.rs
@@ -321,4 +321,36 @@ mod buffer_tests {
 		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
 		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
 	}
+
+	#[test]
+	fn get_str_from_fresh_buffer() {
+		let mut buffer = Buffer::new();
+		let string = buffer.as_str();
+		assert_eq!(string, "");
+	}
+
+	#[test]
+	fn get_str_from_single_node_buffer() {
+		let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
+		let string = buffer.as_str();
+		assert_eq!(string, "\nde\nf\n");
+	}
+
+	#[test]
+	fn get_str_from_multiple_node_buffer() {
+		// warning! this test is coupled with the functionality of insert right now
+		//	a better way would be to explicitly initialise the contents of the buffer
+		let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
+		let mut cursor = Cursor::new();
+
+		buffer.insert_str(&mut cursor, String::from("ab\nc!\n"));
+		cursor.node_idx = 1;
+		cursor.node_offset = 6;
+		cursor.line_idx = 3;
+		cursor.line_offset = 0;
+		buffer.insert_str(&mut cursor, String::from("ghi"));
+
+		let string = buffer.as_str();
+		assert_eq!(string, "ab\nc!\n\nde\nf\nghi");
+	}
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,3 +4,21 @@ pub enum QuitOption {
 	Quitting,
 	NotQuitting,
 }
+
+pub struct Cursor {
+	pub node_idx: usize,
+	pub node_offset: usize,
+	pub line_idx: usize,
+	pub line_offset: usize,
+}
+
+impl Cursor {
+	pub fn new() -> Cursor {
+		Cursor {
+			node_idx: 0,
+			node_offset: 0,
+			line_idx: 0,
+			line_offset: 0,
+		}
+	}
+}

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -26,7 +26,7 @@ impl <B: Backend> View <B> {
 	pub fn update_display(&mut self, app: &App) -> Result<(), io::Error> {
 		let text = app.get_text_as_iter(); // Get a copy of the text to be rendered
 		// For now let's not do anything fancy formatting
-		let text: Vec<_> = text.iter().map(|&x| Text::raw(x) )
+		let text: Vec<_> = text.iter().map(|x| Text::raw(x) )
 						.collect();
 		self.terminal.draw(|mut f| {
 	        let size = f.size();


### PR DESCRIPTION
[ #7 ]

Also used to support #1 , as cursor movement now depends on the implementation of the buffer.

Note: Up/Down cursor movement remains unimplemented for now. 