### PR TITLE
Change indentation of all files from tabs to spaces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,37 +33,37 @@ fn main() -> Result<(), io::Error> {
     // get next event from event queue
     // handle next event, update program state
     loop {
-    	view.update_display(&app)?;
+        view.update_display(&app)?;
 
-    	let event = match events.next() {
-    		Ok(event) => event,
-    		Err(e) => panic!("{:?}", e),
-    	};
+        let event = match events.next() {
+            Ok(event) => event,
+            Err(e) => panic!("{:?}", e),
+        };
 
-    	match handle_event(event, &mut app) {
-    		Ok(QuitOption::Quitting) => break,
-    		Ok(QuitOption::NotQuitting) => {},
-    		Err(x) => panic!("{:?}", x),
-    	};
+        match handle_event(event, &mut app) {
+            Ok(QuitOption::Quitting) => break,
+            Ok(QuitOption::NotQuitting) => {},
+            Err(x) => panic!("{:?}", x),
+        };
     }
 
     Ok(())
 }
 
 fn handle_event(event: Event, app: &mut App) -> Result<QuitOption, ()> {
-	match event {
+    match event {
         // Full list of keys can be found at
         // https://docs.rs/termion/1.1.1/termion/event/enum.Key.html
-		Event::Tick{..} => Ok(QuitOption::NotQuitting),
-		Event::Input{key: Key::Char('q'), ..} => Ok(QuitOption::Quitting),
-		Event::Input{key: Key::Char(c), ..} => {
-			app.add_char(c);
-			Ok(QuitOption::NotQuitting)
-		},
-		Event::Input{key: Key::Backspace, ..} => {
-			app.remove_char();
-			Ok(QuitOption::NotQuitting)
-		},
+        Event::Tick{..} => Ok(QuitOption::NotQuitting),
+        Event::Input{key: Key::Char('q'), ..} => Ok(QuitOption::Quitting),
+        Event::Input{key: Key::Char(c), ..} => {
+            app.add_char(c);
+            Ok(QuitOption::NotQuitting)
+        },
+        Event::Input{key: Key::Backspace, ..} => {
+            app.remove_char();
+            Ok(QuitOption::NotQuitting)
+        },
         Event::Input{key: Key::Right, ..} => {
             app.move_cursor_right();
             Ok(QuitOption::NotQuitting)
@@ -72,8 +72,8 @@ fn handle_event(event: Event, app: &mut App) -> Result<QuitOption, ()> {
             app.move_cursor_left();
             Ok(QuitOption::NotQuitting)
         }
-		_ => Ok(QuitOption::NotQuitting),
-	}
+        _ => Ok(QuitOption::NotQuitting),
+    }
 
 }
 

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -4,55 +4,55 @@ use super::buffer::Buffer;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum AppMode {
-	Edit,
-	Command,
+    Edit,
+    Command,
 }
 
 pub struct App {
-	buffer: Buffer,
-	cursor_main: Cursor,
-	app_mode: AppMode,
+    buffer: Buffer,
+    cursor_main: Cursor,
+    app_mode: AppMode,
 }
 
 impl App {
-	pub fn new() -> App {
-		App {
-			buffer: Buffer::new(),
-			cursor_main: Cursor::new(),
-			app_mode: AppMode::Edit,
-		}
-	}
+    pub fn new() -> App {
+        App {
+            buffer: Buffer::new(),
+            cursor_main: Cursor::new(),
+            app_mode: AppMode::Edit,
+        }
+    }
 
-	// App should only release immutable references to the buffer?
-	pub fn buffer(&self) -> &Buffer {
-		&self.buffer
-	}
+    // App should only release immutable references to the buffer?
+    pub fn buffer(&self) -> &Buffer {
+        &self.buffer
+    }
 
-	pub fn cursor_main(&self) -> &Cursor {
-		&self.cursor_main
-	}
+    pub fn cursor_main(&self) -> &Cursor {
+        &self.cursor_main
+    }
 
-	pub fn app_mode(&self) -> AppMode {
-		self.app_mode
-	}
+    pub fn app_mode(&self) -> AppMode {
+        self.app_mode
+    }
 
-	pub fn get_text_as_iter(&self) -> Vec<String> {
-		vec![self.buffer.as_str()]
-	}
+    pub fn get_text_as_iter(&self) -> Vec<String> {
+        vec![self.buffer.as_str()]
+    }
 
-	pub fn add_char(&mut self, c: char) {
-		self.buffer.insert(&mut self.cursor_main, c);
-	}
+    pub fn add_char(&mut self, c: char) {
+        self.buffer.insert(&mut self.cursor_main, c);
+    }
 
-	pub fn remove_char(&mut self) {
-		self.buffer.remove(&mut self.cursor_main);
-	}
+    pub fn remove_char(&mut self) {
+        self.buffer.remove(&mut self.cursor_main);
+    }
 
-	pub fn move_cursor_left(&mut self) {
-		self.buffer.move_cursor_left(&mut self.cursor_main);
-	}
+    pub fn move_cursor_left(&mut self) {
+        self.buffer.move_cursor_left(&mut self.cursor_main);
+    }
 
-	pub fn move_cursor_right(&mut self) {
-		self.buffer.move_cursor_right(&mut self.cursor_main);
-	}
+    pub fn move_cursor_right(&mut self) {
+        self.buffer.move_cursor_right(&mut self.cursor_main);
+    }
 }

--- a/src/model/buffer.rs
+++ b/src/model/buffer.rs
@@ -171,17 +171,17 @@ impl Buffer {
 
             // construct left and right nodes
             let left_node = BufferNode::new(
-            					from,
-            					index,
-            					cursor.node_offset,
-            					left_line_offsets
-            				);
+                                from,
+                                index,
+                                cursor.node_offset,
+                                left_line_offsets
+                            );
             let right_node = BufferNode::new(
-            					from,
-            					index + cursor.node_offset,
-            					offset - cursor.node_offset,
-            					right_line_offsets
-            				);
+                                from,
+                                index + cursor.node_offset,
+                                offset - cursor.node_offset,
+                                right_line_offsets
+                            );
 
             // add the left, mid, right nodes in in that order to the list
             //  then remove the node that was split into those three
@@ -308,13 +308,13 @@ impl Buffer {
             }
 
             let left_node = BufferNode::new(
-            					from,
+                                from,
                                 index,
                                 index + cursor.node_offset - 1,
                                 left_line_offsets
                             );
             let right_node = BufferNode::new(
-            					from,
+                                from,
                                 index + cursor.node_offset,
                                 offset - cursor.node_offset,
                                 right_line_offsets
@@ -388,13 +388,13 @@ impl Buffer {
                 cursor.line_idx = current_node.line_offsets_len() - 2;
                 cursor.line_offset = cursor.node_offset - current_node.line_offset_at(cursor.line_idx);
             } else {
-            	// the last character of current node should not '\n'
-            	//	so the cursor should point at the last line
-            	cursor.line_idx = current_node.line_offsets_len() - 1;
+                // the last character of current node should not '\n'
+                //	so the cursor should point at the last line
+                cursor.line_idx = current_node.line_offsets_len() - 1;
                 cursor.line_offset = cursor.node_offset - current_node.line_offset_at(cursor.line_idx);
             }
         } else {
-        	// cursor is not at the beginning of the node
+            // cursor is not at the beginning of the node
             cursor.node_offset -= 1;
 
             let current_node: &BufferNode = &self.node_list[cursor.node_idx];
@@ -405,65 +405,65 @@ impl Buffer {
                 cursor.line_idx -= 1;
                 cursor.line_offset = cursor.node_offset - current_node.line_offset_at(cursor.line_idx);
             } else {
-            	// the last character of current node should not be '\n'
-            	//	reduce the line offset by 1
+                // the last character of current node should not be '\n'
+                //	reduce the line offset by 1
                 cursor.line_offset -= 1;
             }
         }
     }
 
     pub fn move_cursor_right(&self, cursor: &mut Cursor) {
-    	if self.node_list.len() == 0 {
-    		// node_list should be empty and thus there is nothing to do
-    		//	so just return
-    		return;
-    	}
+        if self.node_list.len() == 0 {
+            // node_list should be empty and thus there is nothing to do
+            //	so just return
+            return;
+        }
         if cursor.node_idx == self.node_list.len() - 1
-        	&& cursor.node_offset == self.node_list.last().unwrap().offset() {
-        		// cursor should be pointing at the last position in the buffer
-        		//	so there should be nothing to do but return
-        		return;
+            && cursor.node_offset == self.node_list.last().unwrap().offset() {
+                // cursor should be pointing at the last position in the buffer
+                //	so there should be nothing to do but return
+                return;
         }
 
         if cursor.node_offset + 1 == self.node_list.last().unwrap().offset() {
-        	// cursor should be at second last position of the current node
-        	if cursor.node_idx == self.node_list.len() - 1 {
-        		// cursor should be on the last node in the list
-        		//	so just increment the node_offset and line_offset
-        		cursor.node_offset += 1;
-        		let current_node = &self.node_list[cursor.node_idx];
-        		if cursor.node_offset == current_node.last_line_offset() {
-        			// cursor should have passed over a '\n'
-        			cursor.line_idx += 1;
-        			cursor.line_offset = 0;
-        		} else {
-        			// cursor should have passed over something else
-        			cursor.line_offset += 1;
-        		}
-        	} else {
-        		// cursor should have a node on the right
-        		//	point the cursor to the beginning of that node
-	        	cursor.node_idx += 1;
-	        	cursor.node_offset = 0;
-	        	cursor.line_idx = 0;
-	        	cursor.line_offset = 0;
-        	}
+            // cursor should be at second last position of the current node
+            if cursor.node_idx == self.node_list.len() - 1 {
+                // cursor should be on the last node in the list
+                //	so just increment the node_offset and line_offset
+                cursor.node_offset += 1;
+                let current_node = &self.node_list[cursor.node_idx];
+                if cursor.node_offset == current_node.last_line_offset() {
+                    // cursor should have passed over a '\n'
+                    cursor.line_idx += 1;
+                    cursor.line_offset = 0;
+                } else {
+                    // cursor should have passed over something else
+                    cursor.line_offset += 1;
+                }
+            } else {
+                // cursor should have a node on the right
+                //	point the cursor to the beginning of that node
+                cursor.node_idx += 1;
+                cursor.node_offset = 0;
+                cursor.line_idx = 0;
+                cursor.line_offset = 0;
+            }
 
         } else {
-        	// cursor should be still within the same node
-        	//	increase the node_offset by 1
-        	//	update the line index based on whether it has crossed
-        	cursor.node_offset += 1;
-        	let current_node = &self.node_list[cursor.node_idx];
-        	if cursor.node_idx < current_node.line_offsets_len() - 1
-        		&&	cursor.node_offset
-        			== current_node.line_offset_at(cursor.line_idx + 1) {
-        		// cursor should have just passed over a '\n'
-        		cursor.line_idx += 1;
-        		cursor.line_offset = 0;
-        	} else {
-        		cursor.line_offset += 1;
-        	}
+            // cursor should be still within the same node
+            //	increase the node_offset by 1
+            //	update the line index based on whether it has crossed
+            cursor.node_offset += 1;
+            let current_node = &self.node_list[cursor.node_idx];
+            if cursor.node_idx < current_node.line_offsets_len() - 1
+                &&	cursor.node_offset
+                    == current_node.line_offset_at(cursor.line_idx + 1) {
+                // cursor should have just passed over a '\n'
+                cursor.line_idx += 1;
+                cursor.line_offset = 0;
+            } else {
+                cursor.line_offset += 1;
+            }
         }
     }
 

--- a/src/model/tests/buffer_tests.rs
+++ b/src/model/tests/buffer_tests.rs
@@ -1,743 +1,743 @@
 #[cfg(test)]
 mod buffer_tests {
-	use super::super::*;
-
-	fn stov(string: &'static str) -> Vec<u8> {
-		string.as_bytes().to_vec()
-	}
-
-	// get_offsets_tests
-	#[test]
-	fn get_offsets_none() {
-		let string = String::from("abc");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0]);
-	}
-
-	#[test]
-	fn get_offsets_first() {
-		let string = String::from("\nabc");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 1]);
-	}
-
-	#[test]
-	fn get_offsets_last() {
-		let string = String::from("abc\n");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 4]);
-	}
-
-	#[test]
-	fn get_offsets_only() {
-		let string = String::from("\n");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 1]);
-	}
-
-	#[test]
-	fn get_offsets_two() {
-		let string = String::from("\nabc\n");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 1, 5]);
-	}
-
-	#[test]
-	fn get_offsets_consecutive() {
-		let string = String::from("\n\n\n");
-		let offsets = Buffer::get_offsets(&string);
-		assert_eq!(offsets, &[0, 1, 2, 3]);
-	}
-
-	// insert_tests
-	#[test]
-	fn insert_char_into_fresh_buffer() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::new();
-		buffer.insert(&mut cursor, 'a');
-
-		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("a"), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0] );
-		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_newl_into_fresh_buffer() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::new();
-		buffer.insert(&mut cursor, '\n');
-
-		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("\n"), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0, 1] );
-		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_newlnewl_into_fresh_buffer() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::new();
-		let inserted_str = String::from("\n\n");
-		buffer.insert_str(&mut cursor, inserted_str);
-
-		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("\n\n"), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Added, 0, 2, vec![0, 1, 2] );
-		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 2, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_before_node() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
-
-		buffer.insert_str(&mut cursor, String::from("1\n2"));
-
-		assert_eq!(buffer.original_str, stov("abdc\nef"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
-		let node_1 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_after_node() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
-		cursor.node_idx = 0;
-		cursor.node_offset = 7;
-		cursor.line_idx = 1;
-		cursor.line_offset = 2;
-
-		buffer.insert_str(&mut cursor, String::from("1\n2"));
-
-		assert_eq!(buffer.original_str, stov("abdc\nef"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
-		let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_mid_node() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("abdc\nef\ng"));
-		cursor.node_idx = 0;
-		cursor.node_offset = 5;
-		cursor.line_idx = 1;
-		cursor.line_offset = 0;
-
-		buffer.insert_str(&mut cursor, String::from("1\n2"));
-
-		assert_eq!(buffer.original_str, stov("abdc\nef\ng"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 5, vec![0, 5] );
-		let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
-		let node_2 = BufferNode::new(BufferType::Original, 5, 4, vec![0, 3] );
-		assert_eq!(buffer.node_list, vec![node_0, node_1, node_2], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn remove_from_fresh_buffer() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::new();
-
-		buffer.remove(&mut cursor);
-
-		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
-
-		assert_eq!(buffer.node_list, vec![], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn remove_single_char_from_buffer() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("a"));
-		cursor.node_offset = 1;
-		cursor.line_offset = 1;
-
-		buffer.remove(&mut cursor);
-
-		assert_eq!(buffer.original_str, stov("a"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
-
-		assert_eq!(buffer.node_list, vec![], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn remove_left_from_node() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-
-		buffer.remove(&mut cursor);
-
-		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 3, vec![0]);
-		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn remove_from_last_of_node() {
-		let mut cursor = Cursor::new();
-		cursor.node_offset = 3;
-		cursor.line_offset = 3;
-
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-
-		buffer.remove(&mut cursor);
-
-		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 2, vec![0]);
-		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn remove_from_mid_of_node() {
-		let mut cursor = Cursor::new();
-		cursor.node_offset = 2;
-		cursor.line_offset = 2;
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-
-		buffer.remove(&mut cursor);
-
-		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 1, vec![0]);
-		let node_1 = BufferNode::new(BufferType::Original, 2, 1, vec![0]);
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn remove_twice_from_mid_of_node() {
-		let mut cursor = Cursor::new();
-		cursor.node_offset = 2;
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-
-		buffer.remove(&mut cursor);
-		buffer.remove(&mut cursor);
-
-		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 2, 1, vec![0]);
-		assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn remove_with_two_nodes() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-
-		buffer.insert_str(&mut cursor, String::from("\ndef\n"));
-		cursor.node_idx = 1;
-		cursor.node_offset = 0;
-		cursor.line_idx = 0;
-		cursor.line_offset = 0;
-
-		buffer.remove(&mut cursor);
-		buffer.remove(&mut cursor);
-
-		assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("\ndef\n"), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 1]);
-		let node_1 = BufferNode::new(BufferType::Original, 0, 3, vec![0]);
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn remove_with_newlines() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
-		cursor.node_offset = 4;
-		cursor.line_idx = 2;
-		cursor.line_offset = 0;
-
-		buffer.remove(&mut cursor);
-
-		assert_eq!(buffer.original_str, stov("\nde\nf\n"), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
-
-		let node_0 = BufferNode::new(BufferType::Original, 0, 3, vec![0, 1]);
-		let node_1 = BufferNode::new(BufferType::Original, 4, 2, vec![0, 2]);
-		assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_4_then_remove_5() {
-		let mut cursor = Cursor::new();
-		let mut buffer = Buffer::new();
-
-		buffer.insert(&mut cursor, 'a');
-		buffer.insert(&mut cursor, 'b');
-		buffer.insert(&mut cursor, 'c');
-		buffer.insert(&mut cursor, 'd');
-		buffer.remove(&mut cursor);
-		buffer.remove(&mut cursor);
-		buffer.remove(&mut cursor);
-		buffer.remove(&mut cursor);
-		buffer.remove(&mut cursor);
-
-
-		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("abcd"), "added_str mismatch");
-
-		assert_eq!(buffer.node_list, Vec::new(), "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn get_str_from_fresh_buffer() {
-		let mut buffer = Buffer::new();
-		let string = buffer.as_str();
-		assert_eq!(string, "");
-	}
-
-	#[test]
-	fn get_str_from_single_node_buffer() {
-		let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
-		let string = buffer.as_str();
-		assert_eq!(string, "\nde\nf\n");
-	}
-
-	#[test]
-	fn get_str_from_multiple_node_buffer() {
-		// warning! this test is coupled with the functionality of insert right now
-		//	a better way would be to explicitly initialise the contents of the buffer
-		let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
-		let mut cursor = Cursor::new();
-
-		buffer.insert_str(&mut cursor, String::from("ab\nc!\n"));
-		cursor.node_idx = 1;
-		cursor.node_offset = 6;
-		cursor.line_idx = 3;
-		cursor.line_offset = 0;
-		buffer.insert_str(&mut cursor, String::from("ghi"));
-
-		let string = buffer.as_str();
-		assert_eq!(string, "ab\nc!\n\nde\nf\nghi");
-	}
-
-	#[test]
-	fn move_cursor_left_on_fresh_buffer() {
-		let mut buffer = Buffer::new();
-		let mut cursor = Cursor::new();
-
-		buffer.move_cursor_left(&mut cursor);
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_left_idempotent_on_filled_buffer() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-
-		buffer.move_cursor_left(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_left_once_on_filled_buffer() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-		cursor.node_offset = 3;
-		cursor.line_offset = 3;
-
-		buffer.move_cursor_left(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_left_all_the_way_on_filled_buffer() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-		cursor.node_offset = 3;
-		cursor.line_offset = 3;
-
-		buffer.move_cursor_left(&mut cursor);
-		buffer.move_cursor_left(&mut cursor);
-		buffer.move_cursor_left(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_left_across_newline() {
-		let mut buffer = Buffer::with_contents(String::from("ab\nc"));
-		let mut cursor = Cursor::new();
-		cursor.node_offset = 3;
-		cursor.line_idx = 1;
-		cursor.line_offset = 0;
-
-		buffer.move_cursor_left(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_across_two_nodes_from_middle() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-
-		buffer.added_str.append(&mut stov("efg"));
-		let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
-		buffer.node_list.push(added_node);
-
-		cursor.node_idx = 1;
-		cursor.node_offset = 0;
-		cursor.line_idx = 0;
-		cursor.line_offset = 0;
-
-		buffer.move_cursor_left(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_across_two_nodes_from_right_to_middle() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-
-		buffer.added_str.append(&mut stov("efg"));
-		let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
-		buffer.node_list.push(added_node);
-
-		cursor.node_idx = 1;
-		cursor.node_offset = 1;
-		cursor.line_idx = 0;
-		cursor.line_offset = 1;
-
-		buffer.move_cursor_left(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_across_two_nodes_from_right() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-
-		buffer.added_str.append(&mut stov("efg"));
-		let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
-		buffer.node_list.push(added_node);
-
-		cursor.node_idx = 1;
-		cursor.node_offset = 1;
-		cursor.line_idx = 0;
-		cursor.line_offset = 1;
-
-		buffer.move_cursor_left(&mut cursor);
-		buffer.move_cursor_left(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn add_3_and_move_left_once() {
-		let mut buffer = Buffer::new();
-		let mut cursor = Cursor::new();
-
-		buffer.insert(&mut cursor, 'a');
-		buffer.insert(&mut cursor, 'b');
-		buffer.insert(&mut cursor, 'c');
-
-		println!("{:?}", cursor);
-		buffer.move_cursor_left(&mut cursor);
-
-		let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0]);
-		let node_1 = BufferNode::new(BufferType::Added, 1, 1, vec![0]);
-		let node_2 = BufferNode::new(BufferType::Added, 2, 1, vec![0]);
-
-		assert_eq!(buffer.node_list, vec![node_0, node_1, node_2]);
-
-		assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_right_on_fresh_buffer() {
-		let mut buffer = Buffer::new();
-		let mut cursor = Cursor::new();
-
-		buffer.move_cursor_right(&mut cursor);
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_right_idempotent_on_filled_buffer() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-		cursor.node_idx = 0;
-		cursor.node_offset = 3;
-		cursor.line_idx = 0;
-		cursor.line_offset = 3;
-
-		buffer.move_cursor_right(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 3, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_right_once_on_filled_buffer() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-		cursor.node_offset = 1;
-		cursor.line_offset = 1;
-
-		buffer.move_cursor_right(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_right_all_the_way_on_filled_buffer() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-
-		buffer.move_cursor_right(&mut cursor);
-		buffer.move_cursor_right(&mut cursor);
-		buffer.move_cursor_right(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 3, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_right_across_newline() {
-		let mut buffer = Buffer::with_contents(String::from("ab\nc"));
-		let mut cursor = Cursor::new();
-		cursor.node_offset = 2;
-		cursor.line_idx = 0;
-		cursor.line_offset = 2;
-
-		buffer.move_cursor_right(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_right_across_two_nodes_from_middle() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-
-		buffer.added_str.append(&mut stov("efg"));
-		let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
-		buffer.node_list.push(added_node);
-
-		cursor.node_idx = 1;
-		cursor.node_offset = 0;
-		cursor.line_idx = 0;
-		cursor.line_offset = 0;
-
-		buffer.move_cursor_right(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_right_across_two_nodes_from_left_to_middle() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-
-		buffer.added_str.append(&mut stov("efg"));
-		let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
-		buffer.node_list.push(added_node);
-
-		cursor.node_idx = 0;
-		cursor.node_offset = 2;
-		cursor.line_idx = 0;
-		cursor.line_offset = 2;
-
-		buffer.move_cursor_right(&mut cursor);
-
-    	println!("RIGHT PATH!");	
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		println!("RIGHT PATH!");
-		assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
-    	println!("RIGHT PATH!");	
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-    	println!("RIGHT PATH!");
-		assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn move_cursor_right_across_two_nodes_from_left() {
-		let mut buffer = Buffer::with_contents(String::from("abc"));
-		let mut cursor = Cursor::new();
-
-		buffer.added_str.append(&mut stov("efg"));
-		let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
-		buffer.node_list.push(added_node);
-
-		cursor.node_idx = 0;
-		cursor.node_offset = 2;
-		cursor.line_idx = 0;
-		cursor.line_offset = 2;
-
-		buffer.move_cursor_right(&mut cursor);
-		buffer.move_cursor_right(&mut cursor);
-
-		assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
-	}
-
-	#[test]
-	fn insert_left_insert_right_insert() {
-		let mut buffer = Buffer::new();
-		let mut cursor = Cursor::new();
-
-		buffer.insert(&mut cursor, 'a');
-		buffer.move_cursor_left(&mut cursor);
-		buffer.insert(&mut cursor, 'b');
-		buffer.move_cursor_right(&mut cursor);
-		buffer.insert(&mut cursor, 'c');
-
-		let node_0 = BufferNode::new(BufferType::Added, 1, 1, vec![0]);
-		let node_1 = BufferNode::new(BufferType::Added, 0, 1, vec![0]);
-		let node_2 = BufferNode::new(BufferType::Added, 2, 1, vec![0]);
-
-		assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
-		assert_eq!(buffer.added_str, stov("abc"), "added_str mismatch");
-
-		assert_eq!(buffer.node_list, vec![node_0, node_1, node_2], "node_list mismatch");
-
-		assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
-		assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
-		assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
-		assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
-	}
+    use super::super::*;
+
+    fn stov(string: &'static str) -> Vec<u8> {
+        string.as_bytes().to_vec()
+    }
+
+    // get_offsets_tests
+    #[test]
+    fn get_offsets_none() {
+        let string = String::from("abc");
+        let offsets = Buffer::get_offsets(&string);
+        assert_eq!(offsets, &[0]);
+    }
+
+    #[test]
+    fn get_offsets_first() {
+        let string = String::from("\nabc");
+        let offsets = Buffer::get_offsets(&string);
+        assert_eq!(offsets, &[0, 1]);
+    }
+
+    #[test]
+    fn get_offsets_last() {
+        let string = String::from("abc\n");
+        let offsets = Buffer::get_offsets(&string);
+        assert_eq!(offsets, &[0, 4]);
+    }
+
+    #[test]
+    fn get_offsets_only() {
+        let string = String::from("\n");
+        let offsets = Buffer::get_offsets(&string);
+        assert_eq!(offsets, &[0, 1]);
+    }
+
+    #[test]
+    fn get_offsets_two() {
+        let string = String::from("\nabc\n");
+        let offsets = Buffer::get_offsets(&string);
+        assert_eq!(offsets, &[0, 1, 5]);
+    }
+
+    #[test]
+    fn get_offsets_consecutive() {
+        let string = String::from("\n\n\n");
+        let offsets = Buffer::get_offsets(&string);
+        assert_eq!(offsets, &[0, 1, 2, 3]);
+    }
+
+    // insert_tests
+    #[test]
+    fn insert_char_into_fresh_buffer() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::new();
+        buffer.insert(&mut cursor, 'a');
+
+        assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("a"), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0] );
+        assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn insert_newl_into_fresh_buffer() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::new();
+        buffer.insert(&mut cursor, '\n');
+
+        assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("\n"), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0, 1] );
+        assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn insert_newlnewl_into_fresh_buffer() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::new();
+        let inserted_str = String::from("\n\n");
+        buffer.insert_str(&mut cursor, inserted_str);
+
+        assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("\n\n"), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Added, 0, 2, vec![0, 1, 2] );
+        assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 2, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn insert_before_node() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
+
+        buffer.insert_str(&mut cursor, String::from("1\n2"));
+
+        assert_eq!(buffer.original_str, stov("abdc\nef"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+        let node_1 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
+        assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn insert_after_node() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::with_contents(String::from("abdc\nef"));
+        cursor.node_idx = 0;
+        cursor.node_offset = 7;
+        cursor.line_idx = 1;
+        cursor.line_offset = 2;
+
+        buffer.insert_str(&mut cursor, String::from("1\n2"));
+
+        assert_eq!(buffer.original_str, stov("abdc\nef"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Original, 0, 7, vec![0, 5] );
+        let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+        assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn insert_mid_node() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::with_contents(String::from("abdc\nef\ng"));
+        cursor.node_idx = 0;
+        cursor.node_offset = 5;
+        cursor.line_idx = 1;
+        cursor.line_offset = 0;
+
+        buffer.insert_str(&mut cursor, String::from("1\n2"));
+
+        assert_eq!(buffer.original_str, stov("abdc\nef\ng"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("1\n2"), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Original, 0, 5, vec![0, 5] );
+        let node_1 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 2] );
+        let node_2 = BufferNode::new(BufferType::Original, 5, 4, vec![0, 3] );
+        assert_eq!(buffer.node_list, vec![node_0, node_1, node_2], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn remove_from_fresh_buffer() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::new();
+
+        buffer.remove(&mut cursor);
+
+        assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+        assert_eq!(buffer.node_list, vec![], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn remove_single_char_from_buffer() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::with_contents(String::from("a"));
+        cursor.node_offset = 1;
+        cursor.line_offset = 1;
+
+        buffer.remove(&mut cursor);
+
+        assert_eq!(buffer.original_str, stov("a"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+        assert_eq!(buffer.node_list, vec![], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn remove_left_from_node() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+
+        buffer.remove(&mut cursor);
+
+        assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Original, 0, 3, vec![0]);
+        assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn remove_from_last_of_node() {
+        let mut cursor = Cursor::new();
+        cursor.node_offset = 3;
+        cursor.line_offset = 3;
+
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+
+        buffer.remove(&mut cursor);
+
+        assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Original, 0, 2, vec![0]);
+        assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn remove_from_mid_of_node() {
+        let mut cursor = Cursor::new();
+        cursor.node_offset = 2;
+        cursor.line_offset = 2;
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+
+        buffer.remove(&mut cursor);
+
+        assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Original, 0, 1, vec![0]);
+        let node_1 = BufferNode::new(BufferType::Original, 2, 1, vec![0]);
+        assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn remove_twice_from_mid_of_node() {
+        let mut cursor = Cursor::new();
+        cursor.node_offset = 2;
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+
+        buffer.remove(&mut cursor);
+        buffer.remove(&mut cursor);
+
+        assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Original, 2, 1, vec![0]);
+        assert_eq!(buffer.node_list, vec![node_0], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn remove_with_two_nodes() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+
+        buffer.insert_str(&mut cursor, String::from("\ndef\n"));
+        cursor.node_idx = 1;
+        cursor.node_offset = 0;
+        cursor.line_idx = 0;
+        cursor.line_offset = 0;
+
+        buffer.remove(&mut cursor);
+        buffer.remove(&mut cursor);
+
+        assert_eq!(buffer.original_str, stov("abc"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("\ndef\n"), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Added, 0, 3, vec![0, 1]);
+        let node_1 = BufferNode::new(BufferType::Original, 0, 3, vec![0]);
+        assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn remove_with_newlines() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
+        cursor.node_offset = 4;
+        cursor.line_idx = 2;
+        cursor.line_offset = 0;
+
+        buffer.remove(&mut cursor);
+
+        assert_eq!(buffer.original_str, stov("\nde\nf\n"), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov(""), "added_str mismatch");
+
+        let node_0 = BufferNode::new(BufferType::Original, 0, 3, vec![0, 1]);
+        let node_1 = BufferNode::new(BufferType::Original, 4, 2, vec![0, 2]);
+        assert_eq!(buffer.node_list, vec![node_0, node_1], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn insert_4_then_remove_5() {
+        let mut cursor = Cursor::new();
+        let mut buffer = Buffer::new();
+
+        buffer.insert(&mut cursor, 'a');
+        buffer.insert(&mut cursor, 'b');
+        buffer.insert(&mut cursor, 'c');
+        buffer.insert(&mut cursor, 'd');
+        buffer.remove(&mut cursor);
+        buffer.remove(&mut cursor);
+        buffer.remove(&mut cursor);
+        buffer.remove(&mut cursor);
+        buffer.remove(&mut cursor);
+
+
+        assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("abcd"), "added_str mismatch");
+
+        assert_eq!(buffer.node_list, Vec::new(), "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn get_str_from_fresh_buffer() {
+        let mut buffer = Buffer::new();
+        let string = buffer.as_str();
+        assert_eq!(string, "");
+    }
+
+    #[test]
+    fn get_str_from_single_node_buffer() {
+        let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
+        let string = buffer.as_str();
+        assert_eq!(string, "\nde\nf\n");
+    }
+
+    #[test]
+    fn get_str_from_multiple_node_buffer() {
+        // warning! this test is coupled with the functionality of insert right now
+        //	a better way would be to explicitly initialise the contents of the buffer
+        let mut buffer = Buffer::with_contents(String::from("\nde\nf\n"));
+        let mut cursor = Cursor::new();
+
+        buffer.insert_str(&mut cursor, String::from("ab\nc!\n"));
+        cursor.node_idx = 1;
+        cursor.node_offset = 6;
+        cursor.line_idx = 3;
+        cursor.line_offset = 0;
+        buffer.insert_str(&mut cursor, String::from("ghi"));
+
+        let string = buffer.as_str();
+        assert_eq!(string, "ab\nc!\n\nde\nf\nghi");
+    }
+
+    #[test]
+    fn move_cursor_left_on_fresh_buffer() {
+        let mut buffer = Buffer::new();
+        let mut cursor = Cursor::new();
+
+        buffer.move_cursor_left(&mut cursor);
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_left_idempotent_on_filled_buffer() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+
+        buffer.move_cursor_left(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_left_once_on_filled_buffer() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+        cursor.node_offset = 3;
+        cursor.line_offset = 3;
+
+        buffer.move_cursor_left(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_left_all_the_way_on_filled_buffer() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+        cursor.node_offset = 3;
+        cursor.line_offset = 3;
+
+        buffer.move_cursor_left(&mut cursor);
+        buffer.move_cursor_left(&mut cursor);
+        buffer.move_cursor_left(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_left_across_newline() {
+        let mut buffer = Buffer::with_contents(String::from("ab\nc"));
+        let mut cursor = Cursor::new();
+        cursor.node_offset = 3;
+        cursor.line_idx = 1;
+        cursor.line_offset = 0;
+
+        buffer.move_cursor_left(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_across_two_nodes_from_middle() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+
+        buffer.added_str.append(&mut stov("efg"));
+        let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
+        buffer.node_list.push(added_node);
+
+        cursor.node_idx = 1;
+        cursor.node_offset = 0;
+        cursor.line_idx = 0;
+        cursor.line_offset = 0;
+
+        buffer.move_cursor_left(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_across_two_nodes_from_right_to_middle() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+
+        buffer.added_str.append(&mut stov("efg"));
+        let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
+        buffer.node_list.push(added_node);
+
+        cursor.node_idx = 1;
+        cursor.node_offset = 1;
+        cursor.line_idx = 0;
+        cursor.line_offset = 1;
+
+        buffer.move_cursor_left(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_across_two_nodes_from_right() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+
+        buffer.added_str.append(&mut stov("efg"));
+        let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
+        buffer.node_list.push(added_node);
+
+        cursor.node_idx = 1;
+        cursor.node_offset = 1;
+        cursor.line_idx = 0;
+        cursor.line_offset = 1;
+
+        buffer.move_cursor_left(&mut cursor);
+        buffer.move_cursor_left(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn add_3_and_move_left_once() {
+        let mut buffer = Buffer::new();
+        let mut cursor = Cursor::new();
+
+        buffer.insert(&mut cursor, 'a');
+        buffer.insert(&mut cursor, 'b');
+        buffer.insert(&mut cursor, 'c');
+
+        println!("{:?}", cursor);
+        buffer.move_cursor_left(&mut cursor);
+
+        let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0]);
+        let node_1 = BufferNode::new(BufferType::Added, 1, 1, vec![0]);
+        let node_2 = BufferNode::new(BufferType::Added, 2, 1, vec![0]);
+
+        assert_eq!(buffer.node_list, vec![node_0, node_1, node_2]);
+
+        assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_right_on_fresh_buffer() {
+        let mut buffer = Buffer::new();
+        let mut cursor = Cursor::new();
+
+        buffer.move_cursor_right(&mut cursor);
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_right_idempotent_on_filled_buffer() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+        cursor.node_idx = 0;
+        cursor.node_offset = 3;
+        cursor.line_idx = 0;
+        cursor.line_offset = 3;
+
+        buffer.move_cursor_right(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 3, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_right_once_on_filled_buffer() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+        cursor.node_offset = 1;
+        cursor.line_offset = 1;
+
+        buffer.move_cursor_right(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 2, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 2, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_right_all_the_way_on_filled_buffer() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+
+        buffer.move_cursor_right(&mut cursor);
+        buffer.move_cursor_right(&mut cursor);
+        buffer.move_cursor_right(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 3, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_right_across_newline() {
+        let mut buffer = Buffer::with_contents(String::from("ab\nc"));
+        let mut cursor = Cursor::new();
+        cursor.node_offset = 2;
+        cursor.line_idx = 0;
+        cursor.line_offset = 2;
+
+        buffer.move_cursor_right(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 0, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 3, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 1, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_right_across_two_nodes_from_middle() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+
+        buffer.added_str.append(&mut stov("efg"));
+        let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
+        buffer.node_list.push(added_node);
+
+        cursor.node_idx = 1;
+        cursor.node_offset = 0;
+        cursor.line_idx = 0;
+        cursor.line_offset = 0;
+
+        buffer.move_cursor_right(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_right_across_two_nodes_from_left_to_middle() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+
+        buffer.added_str.append(&mut stov("efg"));
+        let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
+        buffer.node_list.push(added_node);
+
+        cursor.node_idx = 0;
+        cursor.node_offset = 2;
+        cursor.line_idx = 0;
+        cursor.line_offset = 2;
+
+        buffer.move_cursor_right(&mut cursor);
+
+        println!("RIGHT PATH!");	
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        println!("RIGHT PATH!");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch");
+        println!("RIGHT PATH!");	
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        println!("RIGHT PATH!");
+        assert_eq!(cursor.line_offset, 0, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn move_cursor_right_across_two_nodes_from_left() {
+        let mut buffer = Buffer::with_contents(String::from("abc"));
+        let mut cursor = Cursor::new();
+
+        buffer.added_str.append(&mut stov("efg"));
+        let added_node = BufferNode::new(BufferType::Added, 0, 3, vec![0]);
+        buffer.node_list.push(added_node);
+
+        cursor.node_idx = 0;
+        cursor.node_offset = 2;
+        cursor.line_idx = 0;
+        cursor.line_offset = 2;
+
+        buffer.move_cursor_right(&mut cursor);
+        buffer.move_cursor_right(&mut cursor);
+
+        assert_eq!(cursor.node_idx, 1, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+    }
+
+    #[test]
+    fn insert_left_insert_right_insert() {
+        let mut buffer = Buffer::new();
+        let mut cursor = Cursor::new();
+
+        buffer.insert(&mut cursor, 'a');
+        buffer.move_cursor_left(&mut cursor);
+        buffer.insert(&mut cursor, 'b');
+        buffer.move_cursor_right(&mut cursor);
+        buffer.insert(&mut cursor, 'c');
+
+        let node_0 = BufferNode::new(BufferType::Added, 1, 1, vec![0]);
+        let node_1 = BufferNode::new(BufferType::Added, 0, 1, vec![0]);
+        let node_2 = BufferNode::new(BufferType::Added, 2, 1, vec![0]);
+
+        assert_eq!(buffer.original_str, stov(""), "original_str mismatch");
+        assert_eq!(buffer.added_str, stov("abc"), "added_str mismatch");
+
+        assert_eq!(buffer.node_list, vec![node_0, node_1, node_2], "node_list mismatch");
+
+        assert_eq!(cursor.node_idx, 2, "cursor.node_idx mismatch");
+        assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch");
+        assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch");
+    }
 }

--- a/src/utils/events.rs
+++ b/src/utils/events.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::sync::mpsc::{
-	self,
-	Sender
+    self,
+    Sender
 };
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -14,12 +14,12 @@ use termion::event::Key;
 use termion::input::TermRead;
 
 pub enum Event {
-	Tick {time: SystemTime},
-	Input {key: Key, time: SystemTime}
+    Tick {time: SystemTime},
+    Input {key: Key, time: SystemTime}
 }
 
 pub struct Events {
-	rx: mpsc::Receiver<Event>,
+    rx: mpsc::Receiver<Event>,
     input_handle: thread::JoinHandle<()>,
     ignore_exit_key: Arc<AtomicBool>,
     tick_handle: thread::JoinHandle<()>,
@@ -69,14 +69,14 @@ impl Events {
     }
 
     fn input_thread(ignore_exit_key: Arc<AtomicBool>, tx: Sender<Event>, exit_key: Key) {
-    	let stdin = io::stdin();
+        let stdin = io::stdin();
         for evt in stdin.keys() {
             match evt {
                 Ok(key) => {
-                	let to_send = Event::Input {
-                		key: key,
-                		time: SystemTime::now(),
-                	};
+                    let to_send = Event::Input {
+                        key: key,
+                        time: SystemTime::now(),
+                    };
 
                     if let Err(_) = tx.send(to_send) {
                         return;
@@ -93,9 +93,9 @@ impl Events {
     fn tick_thread(tx: Sender<Event>, tick_rate: Duration) {
         let tx = tx.clone();
         loop {
-        	let to_send = Event::Tick {
-	    		time: SystemTime::now(),
-        	};
+            let to_send = Event::Tick {
+                time: SystemTime::now(),
+            };
             tx.send(to_send).unwrap();
             thread::sleep(tick_rate);
         }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,25 +1,25 @@
 pub mod events;
 
 pub enum QuitOption {
-	Quitting,
-	NotQuitting,
+    Quitting,
+    NotQuitting,
 }
 
 #[derive(Debug)]
 pub struct Cursor {
-	pub node_idx: usize,
-	pub node_offset: usize,
-	pub line_idx: usize,
-	pub line_offset: usize,
+    pub node_idx: usize,
+    pub node_offset: usize,
+    pub line_idx: usize,
+    pub line_offset: usize,
 }
 
 impl Cursor {
-	pub fn new() -> Cursor {
-		Cursor {
-			node_idx: 0,
-			node_offset: 0,
-			line_idx: 0,
-			line_offset: 0,
-		}
-	}
+    pub fn new() -> Cursor {
+        Cursor {
+            node_idx: 0,
+            node_offset: 0,
+            line_idx: 0,
+            line_offset: 0,
+        }
+    }
 }

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -11,35 +11,35 @@ use tui::{
 use crate::model::app::App;
 
 pub struct View<B: Backend> {
-	terminal: Terminal<B>,
-	// Probably want to include layout details
-	//  here eventually.
+    terminal: Terminal<B>,
+    // Probably want to include layout details
+    //  here eventually.
 }
 
 impl <B: Backend> View <B> {
-	pub fn new(terminal: Terminal<B>) -> View<B> {
-		View {
-			terminal: terminal
-		}
-	}
+    pub fn new(terminal: Terminal<B>) -> View<B> {
+        View {
+            terminal: terminal
+        }
+    }
 
-	pub fn update_display(&mut self, app: &App) -> Result<(), io::Error> {
-		let text = app.get_text_as_iter(); // Get a copy of the text to be rendered
-		// For now let's not do anything fancy formatting
-		let text: Vec<_> = text.iter().map(|x| Text::raw(x) )
-						.collect();
-		self.terminal.draw(|mut f| {
-	        let size = f.size();
-	        let block = Paragraph::new(text.iter())
-					    .block(Block::default().title("Paragraph").borders(Borders::ALL))
-					    .style(Style::default().fg(Color::White).bg(Color::Black))
-					    .alignment(Alignment::Left)
-					    .wrap(true);
-	        f.render_widget(block, size);
-    	})?;
+    pub fn update_display(&mut self, app: &App) -> Result<(), io::Error> {
+        let text = app.get_text_as_iter(); // Get a copy of the text to be rendered
+        // For now let's not do anything fancy formatting
+        let text: Vec<_> = text.iter().map(|x| Text::raw(x) )
+                        .collect();
+        self.terminal.draw(|mut f| {
+            let size = f.size();
+            let block = Paragraph::new(text.iter())
+                        .block(Block::default().title("Paragraph").borders(Borders::ALL))
+                        .style(Style::default().fg(Color::White).bg(Color::Black))
+                        .alignment(Alignment::Left)
+                        .wrap(true);
+            f.render_widget(block, size);
+        })?;
 
-    	Ok(())
-	}
+        Ok(())
+    }
 
 
 }


### PR DESCRIPTION
I used VSCode's "Convert indentation to spaces" feature on all the current files. I am applying these changes to a single PR first so that tabs to spaces conversion won't be mixed with feature changes in future PRs.