### PR TITLE
(False Alarm) Fix CI not sending codecov reports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,6 @@
 mod tests {
     #[test]
     fn dummy_test() {
-        assert_eq!(2 + 2, 4);
+        assert_eq!(2 + 2 - 1, 3);
     }
 }


### PR DESCRIPTION
There seems to be a problem with Travis, as it is unable to send codecov reports anymore as of yesterday (30 May 2020 around 8pm SGT). It says that SSL Verification failed as screenshot:
![2020-05-31 09 30 22](https://user-images.githubusercontent.com/39089453/83342377-63183300-a321-11ea-9ec8-058c7878434d.jpg)

This PR is my attempt at fixing it