### PR TITLE
Cursor movement bugfix

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,16 @@ fn handle_event(event: Event, app: &mut App) -> Result<QuitOption, ()> {
             app.move_cursor_left();
             Ok(QuitOption::NotQuitting)
         }
+        Event::Input {
+            key: Key::Up, ..
+        } => {
+            app.move_cursor_up();
+            Ok(QuitOption::NotQuitting)
+        }
+        Event::Input { key: Key::Down, .. } => {
+            app.move_cursor_down();
+            Ok(QuitOption::NotQuitting)
+        }
         _ => Ok(QuitOption::NotQuitting),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,9 +82,7 @@ fn handle_event(event: Event, app: &mut App) -> Result<QuitOption, ()> {
             app.move_cursor_left();
             Ok(QuitOption::NotQuitting)
         }
-        Event::Input {
-            key: Key::Up, ..
-        } => {
+        Event::Input { key: Key::Up, .. } => {
             app.move_cursor_up();
             Ok(QuitOption::NotQuitting)
         }

--- a/src/model/app.rs
+++ b/src/model/app.rs
@@ -48,4 +48,12 @@ impl App {
     pub fn move_cursor_right(&mut self) {
         self.buffer.move_cursor_right();
     }
+
+    pub fn move_cursor_up(&mut self) {
+        self.buffer.move_cursor_up();
+    }
+
+    pub fn move_cursor_down(&mut self) {
+        self.buffer.move_cursor_down();
+    }
 }

--- a/src/model/buffer.rs
+++ b/src/model/buffer.rs
@@ -140,8 +140,6 @@ impl Buffer {
             assert_eq!(self.cursor.line_idx, 0);
             // just insert the new node before current node
             //	which is where the cursor is
-            self.cursor.node_offset = new_node.offset();
-            self.cursor.line_idx = new_node.line_offsets_len() - 1;
             self.cursor.line_offset = line_idx_update(self.cursor.line_offset);
             self.cursor.original_line_offset = self.cursor.line_offset;
             self.node_list.insert_prev(new_node);

--- a/src/model/tests/buffer_tests.rs
+++ b/src/model/tests/buffer_tests.rs
@@ -49,7 +49,7 @@ mod buffer_tests {
         buffer.insert('b');
 
         let cursor = buffer.cursor;
-        assert_eq!(cursor.node_offset, 1, "cursor.node_offset mismatch!");
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch!");
         assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch!");
         assert_eq!(cursor.line_offset, 1, "cursor.line_offset mismatch!");
         assert_eq!(
@@ -1898,5 +1898,51 @@ mod buffer_tests {
 
         assert_eq!(buffer.node_list.index(), 3, "node_list index mismatch!");
         assert_eq!(buffer.current_line, 2, "buffer.current_line mismatch!");
+    }
+
+    #[test]
+    fn random_test() {
+        let mut buffer = Buffer::new();
+
+        buffer.insert('1');
+        buffer.insert('2');
+        buffer.insert('3');
+        buffer.insert('4');
+
+        println!("{:?}", buffer.cursor);
+        println!("{:?}", buffer.node_list.index());
+        buffer.move_cursor_left();
+        println!("{:?}", buffer.cursor);
+        println!("{:?}", buffer.node_list.index());
+        buffer.insert('5');
+        buffer.insert('6');
+
+
+        let cursor = buffer.cursor;
+        assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch!");
+        assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch!");
+        assert_eq!(cursor.line_offset, 5, "cursor.line_offset mismatch!");
+        assert_eq!(
+            cursor.original_line_offset, cursor.line_offset,
+            "cursor.line_offset mismatch!"
+        );
+
+        assert_eq!(buffer.original_str, stov(""), "original_str mismatch!");
+        assert_eq!(buffer.added_str, stov("123456"), "added_str mismatch!");
+
+        let node_0 = BufferNode::new(BufferType::Added, 0, 1, vec![0]);
+        let node_1 = BufferNode::new(BufferType::Added, 1, 1, vec![0]);
+        let node_2 = BufferNode::new(BufferType::Added, 2, 1, vec![0]);
+        let node_3 = BufferNode::new(BufferType::Added, 4, 1, vec![0]);
+        let node_4 = BufferNode::new(BufferType::Added, 5, 1, vec![0]);
+        let node_5 = BufferNode::new(BufferType::Added, 3, 1, vec![0]);
+        assert_eq!(
+            buffer.node_list,
+            vec![node_0, node_1, node_2, node_3, node_4, node_5],
+            "node_list contents mismatch!"
+        );
+        assert_eq!(buffer.node_list.index(), 5);
+
+        assert_eq!(buffer.current_line, 0, "buffer.current_line mismatch!");
     }
 }

--- a/src/model/tests/buffer_tests.rs
+++ b/src/model/tests/buffer_tests.rs
@@ -1917,7 +1917,6 @@ mod buffer_tests {
         buffer.insert('5');
         buffer.insert('6');
 
-
         let cursor = buffer.cursor;
         assert_eq!(cursor.node_offset, 0, "cursor.node_offset mismatch!");
         assert_eq!(cursor.line_idx, 0, "cursor.line_idx mismatch!");


### PR DESCRIPTION
* Fixes crashing issue insertion after left cursor movement
* Binds up/down arrow keys to up/down cursor movement